### PR TITLE
Fix: Crash if volume scale never moved

### DIFF
--- a/actions/SetVolume.py
+++ b/actions/SetVolume.py
@@ -93,7 +93,11 @@ class SetVolume(ActionBase):
     def on_key_down(self):
         settings = self.get_settings()
         device_name = settings.get("device")
-        volume_change = settings.get("volume_change")
+        volume_change = settings.get("volume_change", 0)
+
+        if None in (device_name, volume_change):
+            self.show_error(1)
+            return
 
         for sink in self.plugin_base.pulse.sink_list():
             proplist = sink.proplist

--- a/actions/VolumeAdjust.py
+++ b/actions/VolumeAdjust.py
@@ -94,7 +94,11 @@ class VolumeAdjust(ActionBase):
     def on_key_down(self):
         settings = self.get_settings()
         device_name = settings.get("device")
-        volume_change = settings.get("volume_change")
+        volume_change = settings.get("volume_change", 0)
+
+        if None in (device_name, volume_change):
+            self.show_error(1)
+            return
 
         for sink in self.plugin_base.pulse.sink_list():
             proplist = sink.proplist


### PR DESCRIPTION
The app crashed if no volume setting is present