### PR TITLE
Fix: Maintain device binding when configured device is unavailable

### DIFF
--- a/actions/AdjustVolume.py
+++ b/actions/AdjustVolume.py
@@ -90,6 +90,10 @@ class AdjustVolume(AudioCore):
         try:
             device = get_device(self.device_filter, self.selected_device.pulse_name)
 
+            # Silently skip if device unavailable
+            if device is None:
+                return
+
             if adjustment < 0:
                 change_volume(device, adjustment)
                 return

--- a/actions/SetDefaultDevice.py
+++ b/actions/SetDefaultDevice.py
@@ -46,6 +46,12 @@ class SetDefaultDevice(AudioCore):
             return
 
         try:
+            device = get_device(self.device_filter, self.selected_device.pulse_name)
+
+            # Silently skip if device unavailable
+            if device is None:
+                return
+
             set_default_device(self.device_filter, self.selected_device.pulse_name)
             self.display_device_info()
             self.set_current_icon()
@@ -58,7 +64,11 @@ class SetDefaultDevice(AudioCore):
     def set_current_icon(self):
         standard_device = get_standard_device(self.device_filter)
 
-        if standard_device.name == self.selected_device.pulse_name:
+        # Handle unavailable devices gracefully
+        if standard_device is None or self.selected_device is None:
+            self._current_icon = self.get_icon(Icons.NONE_DEFAULT)
+            self._icon_name = Icons.NONE_DEFAULT
+        elif standard_device.name == self.selected_device.pulse_name:
             self._current_icon = self.get_icon(Icons.HEADPHONE_DEFAULT)
             self._icon_name = Icons.HEADPHONE_DEFAULT
         else:
@@ -69,6 +79,9 @@ class SetDefaultDevice(AudioCore):
 
     def display_adjustment(self):
         standard_device = get_standard_device(self.device_filter)
+
+        if standard_device is None or self.selected_device is None:
+            return ""
 
         if standard_device.name == self.selected_device.pulse_name:
             return "SELECTED"

--- a/actions/SetVolume.py
+++ b/actions/SetVolume.py
@@ -74,6 +74,11 @@ class SetVolume(AudioCore):
 
         try:
             device = get_device(self.device_filter, self.selected_device.pulse_name)
+
+            # Silently skip if device unavailable
+            if device is None:
+                return
+
             set_volume(device, self.volume)
         except Exception as e:
             log.error(e)

--- a/actions/VolumeWarning.py
+++ b/actions/VolumeWarning.py
@@ -1,5 +1,7 @@
 from enum import Enum
 
+from loguru import logger as log
+
 from GtkHelper.ComboRow import SimpleComboRowItem
 from GtkHelper.GenerativeUI.ColorButtonRow import ColorButtonRow
 from GtkHelper.GenerativeUI.ComboRow import ComboRow
@@ -135,7 +137,18 @@ class VolumeWarning(AudioCore):
         if self.warning_color is None or self.default_color is None:
             return
 
+        # Handle case when device is unavailable
+        if self.selected_device is None:
+            self.set_background_color(list(self.default_color))
+            return
+
         volumes = get_volumes_from_device(self.device_filter, self.selected_device.pulse_name)
+
+        # If device unavailable, show default color
+        if len(volumes) == 0:
+            self.set_background_color(list(self.default_color))
+            return
+
         volume = volumes[0]
 
         if self.comparator == Comparator.GT.value and volume > self.warning_threshold:


### PR DESCRIPTION
Everything in this PR is by Claude Code; I've read it and tested it myself.

When a configured audio device (e.g., Bluetooth headphones) becomes unavailable, controls now remain bound to that device and silently skip operations, rather than falling back to control the default device.

Changes:
- Added device validation in PulseHelpers to verify returned device matches requested device name
- Modified all actions (SetVolume, AdjustVolume, Mute, SetDefaultDevice, VolumeWarning) to silently skip operations when the configured device is unavailable
- Created placeholder Device objects for unavailable devices to maintain binding at startup
- Automatically reload device list when devices are added/removed via PulseAudio events
- Store human-readable device names so they can be displayed for unavailable devices
- Display "N/A" for volume when device is offline

Behavior:
- Device connected: Controls work normally
- Device disconnected: Controls do nothing, display shows device name with "(Unavailable)" and volume shows "N/A"
- Device reconnected: Controls immediately resume working

🤖 Generated with [Claude Code](https://claude.com/claude-code)